### PR TITLE
Refactor CLI into a subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,20 @@
 use std::time::Duration;
 
 use chrono::Utc;
-use clap::Parser;
-use log::{debug, warn};
+use clap::{Parser, Subcommand};
+use log::{debug, info, warn};
 use reqwest::Method;
 
-const ARTIFACT: &str = "llvm-tools-nightly-aarch64-unknown-linux-gnu.tar.gz";
+use crate::releases::ReleasesCommand;
+
+mod releases;
 
 /// Gather data for debugging rust-lang/simpleinfra#340
 #[derive(Debug, Parser)]
-struct Args {
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+
     /// Maximum number of attempts to download an uncached artifacts
     #[arg(short, long, default_value_t = 20)]
     attempts: usize,
@@ -19,8 +24,21 @@ struct Args {
     samples: usize,
 }
 
+#[derive(Debug, Subcommand)]
+enum Commands {
+    Releases,
+}
+
+trait Command {
+    fn next_step(&mut self) -> Option<String>;
+
+    fn cloudfront_url(&self) -> Option<String>;
+    fn fastly_url(&self) -> Option<String>;
+    fn s3_url(&self) -> Option<String>;
+}
+
 struct Stats {
-    day: String,
+    step: String,
     fastly: usize,
     cloudfront: usize,
     s3: usize,
@@ -29,26 +47,33 @@ struct Stats {
 fn main() {
     env_logger::init();
 
-    let args = Args::parse();
+    let cli = Cli::parse();
+    let mut command = match cli.command {
+        Commands::Releases => ReleasesCommand::new(),
+    };
+
     let mut output = Vec::new();
-
     let mut attempts = 0;
-    let date = Utc::now().date_naive();
 
-    while output.len() < args.samples && attempts < args.attempts {
-        let day = (date - chrono::Duration::days(attempts as i64))
-            .format("%Y-%m-%d")
-            .to_string();
+    while output.len() < cli.samples && attempts < cli.attempts {
+        if let Some(step) = command.next_step() {
+            info!("downloading artifacts for {}", step);
 
-        debug!("downloading artifacts for {}", day);
+            let stats = download_artifacts(
+                &step,
+                command.cloudfront_url().unwrap(),
+                command.fastly_url().unwrap(),
+                command.s3_url().unwrap(),
+            );
 
-        let stats = download_artifacts(&day);
+            if let Some(stats) = stats {
+                output.push(stats);
+            }
 
-        if let Some(stats) = stats {
-            output.push(stats);
+            attempts += 1;
+        } else {
+            break;
         }
-
-        attempts += 1;
     }
 
     println!("| Date       | Fastly     | Cloudfront | S3         |");
@@ -56,38 +81,27 @@ fn main() {
     for stat in output {
         println!(
             "| {} | {:>10} | {:>10} | {:>10} |",
-            stat.day, stat.fastly, stat.cloudfront, stat.s3
+            stat.step, stat.fastly, stat.cloudfront, stat.s3
         );
     }
 }
 
-fn download_artifacts(day: &str) -> Option<Stats> {
-    let fastly = download_from_fastly(day)?;
-    let cloudfront = download_from_cloudfront(day)?;
-    let s3 = download_from_s3(day)?;
+fn download_artifacts(
+    step: &str,
+    cloudfront_url: String,
+    fastly_url: String,
+    s3_url: String,
+) -> Option<Stats> {
+    let fastly = download(&fastly_url, Some("x-cache"), Some("HIT"))?;
+    let cloudfront = download(&cloudfront_url, Some("x-cache"), Some("Hit"))?;
+    let s3 = download(&s3_url, None, None)?;
 
     Some(Stats {
-        day: day.to_string(),
+        step: step.to_string(),
         fastly,
         cloudfront,
         s3,
     })
-}
-
-fn download_from_fastly(day: &str) -> Option<usize> {
-    let url = format!("https://fastly-static.rust-lang.org/dist/{day}/{ARTIFACT}");
-    download(&url, Some("x-cache"), Some("HIT"))
-}
-
-fn download_from_cloudfront(day: &str) -> Option<usize> {
-    let url = format!("https://cloudfront-static.rust-lang.org/dist/{day}/{ARTIFACT}");
-    download(&url, Some("x-cache"), Some("Hit"))
-}
-
-fn download_from_s3(day: &str) -> Option<usize> {
-    let url =
-        format!("https://static-rust-lang-org.s3.us-west-1.amazonaws.com/dist/{day}/{ARTIFACT}");
-    download(&url, None, None)
 }
 
 fn download(
@@ -134,10 +148,7 @@ fn download(
     let end_time = Utc::now();
     let duration = end_time - start_time;
 
-    debug!(
-        "downloaded {} MB from CloudFront",
-        bytes.len() / 1000 / 1000
-    );
+    debug!("downloaded {} MB", bytes.len() / 1000 / 1000);
     debug!("start time: {}, end time: {}", start_time, end_time);
 
     let speed_in_kb = bytes.len() as f64 / 1000.0 / duration.num_seconds() as f64;

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -1,0 +1,60 @@
+use chrono::{Days, Duration, NaiveDate, Utc};
+
+use crate::Command;
+
+const ARTIFACT: &str = "llvm-tools-nightly-aarch64-unknown-linux-gnu.tar.gz";
+
+#[derive(Debug, Default)]
+pub struct ReleasesCommand {
+    current_step: Option<NaiveDate>,
+}
+
+impl ReleasesCommand {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Command for ReleasesCommand {
+    fn next_step(&mut self) -> Option<String> {
+        let current_step = self.current_step.unwrap_or_else(|| {
+            Utc::now()
+                .checked_add_days(Days::new(1))
+                .unwrap()
+                .date_naive()
+        });
+
+        let next_step = current_step - Duration::days(1);
+        self.current_step = Some(next_step);
+
+        Some(format_step(&next_step))
+    }
+
+    fn cloudfront_url(&self) -> Option<String> {
+        let step = self.current_step?;
+
+        Some(format!(
+            "https://cloudfront-static.rust-lang.org/dist/{step}/{ARTIFACT}"
+        ))
+    }
+
+    fn fastly_url(&self) -> Option<String> {
+        let step = self.current_step?;
+
+        Some(format!(
+            "https://fastly-static.rust-lang.org/dist/{step}/{ARTIFACT}"
+        ))
+    }
+
+    fn s3_url(&self) -> Option<String> {
+        let step = self.current_step?;
+
+        Some(format!(
+            "https://static-rust-lang-org.s3.us-west-1.amazonaws.com/dist/{step}/{ARTIFACT}"
+        ))
+    }
+}
+
+fn format_step(date: &NaiveDate) -> String {
+    date.format("%Y-%m-%d").to_string()
+}


### PR DESCRIPTION
The program has been refactored into a CLI with a subcommand. This makes it possible to implement the same experiment for crates more easily.