### PR TITLE
Gather data for crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,6 +833,8 @@ dependencies = [
  "env_logger",
  "log",
  "reqwest",
+ "semver",
+ "serde",
 ]
 
 [[package]]
@@ -890,6 +892,15 @@ checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,6 @@ chrono = "0.4.26"
 clap = { version = "4.4.1", features = ["derive"] }
 env_logger = "0.10.0"
 log = "0.4.20"
-reqwest = { version = "0.11.20", features = ["blocking"] }
+reqwest = { version = "0.11.20", features = ["blocking", "json"] }
+semver = { version = "1.0.18", features = ["serde"] }
+serde = { version = "1.0.188", features = ["derive"] }

--- a/src/crates.rs
+++ b/src/crates.rs
@@ -1,0 +1,88 @@
+use std::vec::IntoIter;
+
+use log::debug;
+use reqwest::header::{ACCEPT, USER_AGENT};
+use semver::Version;
+use serde::Deserialize;
+
+use crate::Command;
+
+pub struct CratesCommand {
+    krate: String,
+    versions: IntoIter<Version>,
+    current_version: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct VersionsPayload {
+    versions: Vec<VersionPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+struct VersionPayload {
+    num: Version,
+}
+
+impl CratesCommand {
+    pub fn new(krate: String) -> Self {
+        debug!("fetching versions for {}", krate);
+
+        let response = reqwest::blocking::Client::new()
+            .get(format!("https://crates.io/api/v1/crates/{krate}/versions"))
+            .header(ACCEPT, "application/json")
+            .header(USER_AGENT, "jdno/rust-simpleinfra-340")
+            .send()
+            .unwrap();
+
+        let versions = response
+            .json::<VersionsPayload>()
+            .unwrap()
+            .versions
+            .into_iter()
+            .map(|payload| payload.num)
+            .collect::<Vec<Version>>()
+            .into_iter();
+
+        Self {
+            krate,
+            versions,
+            current_version: None,
+        }
+    }
+}
+
+impl Command for CratesCommand {
+    fn next_step(&mut self) -> Option<String> {
+        let current_version = self.versions.next().map(|version| version.to_string());
+        self.current_version = current_version.clone();
+
+        current_version
+    }
+
+    fn cloudfront_url(&self) -> Option<String> {
+        self.current_version.as_ref().map(|step| {
+            format!(
+                "https://cloudfront-static.crates.io/crates/{}/{}-{}.crate",
+                self.krate, self.krate, step
+            )
+        })
+    }
+
+    fn fastly_url(&self) -> Option<String> {
+        self.current_version.as_ref().map(|step| {
+            format!(
+                "https://fastly-static.crates.io/crates/{}/{}-{}.crate",
+                self.krate, self.krate, step
+            )
+        })
+    }
+
+    fn s3_url(&self) -> Option<String> {
+        self.current_version.as_ref().map(|step| {
+            format!(
+                "https://crates-io.s3.us-west-1.amazonaws.com/crates/{}/{}-{}.crate",
+                self.krate, self.krate, step
+            )
+        })
+    }
+}


### PR DESCRIPTION
The CLI has been extended to gather data for crates.io as well. This enables us to compare the performance of our Compute@Edge and VCL services.